### PR TITLE
feat(map): Add event callback for map movement

### DIFF
--- a/.changeset/strange-waves-matter.md
+++ b/.changeset/strange-waves-matter.md
@@ -1,0 +1,5 @@
+---
+"@balloman/expo-google-maps": minor
+---
+
+Added an event callback for while the map is being moved

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -27,6 +27,9 @@ export default function App() {
         onMapIdle={({ cameraPosition }) =>
           console.log("cameraPosition", cameraPosition)
         }
+        onDidChange={({ cameraPosition }) =>
+          console.log("onDidChange", cameraPosition)
+        }
         polygons={[
           {
             key: "1",

--- a/ios/ExpoGoogleMapsModule.swift
+++ b/ios/ExpoGoogleMapsModule.swift
@@ -57,6 +57,7 @@ public class ExpoGoogleMapsModule: Module {
       }
       
       Events("onMapIdle")
+      Events("onDidChange")
 
       //Animates camera to given location
       AsyncFunction("animateCamera") { (view: MapView, camera: Camera, animationOptions: AnimateOptions?) in

--- a/ios/Views/MapView.swift
+++ b/ios/Views/MapView.swift
@@ -6,6 +6,7 @@ import GoogleMaps
 class MapView: ExpoView, GMSMapViewDelegate {
   let mapView: GMSMapView?
   let onMapIdle = EventDispatcher()
+  let onDidChange = EventDispatcher()
   private var markers: [MarkerView] = []
   private var polygons: [String: GMSPolygon] = [:]
   var propPolygons: [Polygon] = []
@@ -90,9 +91,14 @@ class MapView: ExpoView, GMSMapViewDelegate {
   // MARK: MapViewDelegate
   
   func mapView(_ mapView: GMSMapView, idleAt cameraPosition: GMSCameraPosition) {
-    print("Map Idle", cameraPosition, cameraPosition.toCameraRecord())
     onMapIdle([
       "cameraPosition": cameraPosition.toCameraRecord().toDictionary()
+    ])
+  }
+  
+  func mapView(_ mapView: GMSMapView, didChange position: GMSCameraPosition) {
+    onDidChange([
+      "cameraPosition": position.toCameraRecord().toDictionary()
     ])
   }
 }

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -9,22 +9,6 @@ import {
   Polygon,
 } from "./ExpoGoogleMaps.types";
 
-export type MapViewProps = {
-  /** A prop to modify the camera */
-  camera: Camera;
-  /** Any polygons to display on the map */
-  polygons?: Polygon[];
-  /** A ref to the imperative functions of the map */
-  mapRef?: React.Ref<MapFunctions>;
-  /** A json string of the style to apply to the map, if needed. See here: https://mapstyle.withgoogle.com/ */
-  styleJson?: string;
-  /** A callback for when the map is idle after being moved */
-  onMapIdle?: (event: {
-    /** The position of the camera */
-    cameraPosition: Camera;
-  }) => void;
-} & ViewProps;
-
 export type MapFunctions = {
   /**
    * Animates the camera to the given position @see {@link Camera}
@@ -47,9 +31,38 @@ export type MapFunctions = {
   ): Promise<void>;
 };
 
-type NativeViewProps = Omit<MapViewProps, "onMapIdle"> & {
+export type MapViewProps = MapProperties & MapEvents;
+
+type MapEvents = {
+  /** A callback for when the map is idle after being moved */
+  onMapIdle?: (event: {
+    /** The position of the camera */
+    cameraPosition: Camera;
+  }) => void;
+  /** A callback that is called repeatedly during any animations or gestures on the map (or once, if the camera is explicitly set).
+   * This may not be called for all intermediate camera positions. It is always called for the final position of an animation or gesture.
+   */
+  onDidChange?: (event: {
+    /** The position of the camera */
+    cameraPosition: Camera;
+  }) => void;
+};
+
+type MapProperties = {
+  /** A prop to modify the camera */
+  camera: Camera;
+  /** Any polygons to display on the map */
+  polygons?: Polygon[];
+  /** A ref to the imperative functions of the map */
+  mapRef?: React.Ref<MapFunctions>;
+  /** A json string of the style to apply to the map, if needed. See here: https://mapstyle.withgoogle.com/ */
+  styleJson?: string;
+} & ViewProps;
+
+type NativeViewProps = MapProperties & {
   ref?: React.Ref<MapFunctions>;
   onMapIdle?: (event: { nativeEvent: { cameraPosition: Camera } }) => void;
+  onDidChange?: (event: { nativeEvent: { cameraPosition: Camera } }) => void;
 };
 
 const NativeView: React.ComponentType<NativeViewProps> =
@@ -62,7 +75,18 @@ export function MapView(props: MapViewProps) {
     props.onMapIdle?.({ cameraPosition: event.nativeEvent.cameraPosition });
   };
 
+  const innerOnDidChange = (event: {
+    nativeEvent: { cameraPosition: Camera };
+  }) => {
+    props.onDidChange?.({ cameraPosition: event.nativeEvent.cameraPosition });
+  };
+
   return (
-    <NativeView {...props} onMapIdle={innerOnMapIdle} ref={props.mapRef} />
+    <NativeView
+      {...props}
+      onMapIdle={innerOnMapIdle}
+      onDidChange={innerOnDidChange}
+      ref={props.mapRef}
+    />
   );
 }


### PR DESCRIPTION
This pull request adds a new event callback for when the map is being moved, called `onDidChange`. This callback is triggered repeatedly during any animations or gestures on the map, or once if the camera is explicitly set. It provides the position of the camera as a parameter. This feature was implemented by adding the `onDidChange` event to the `MapView` class and updating the `MapViewProps` and `NativeViewProps` interfaces to include it.

Fixes #11