### PR TITLE
feat(map): The user's location can now be visible on the map

### DIFF
--- a/.changeset/chatty-rockets-pay.md
+++ b/.changeset/chatty-rockets-pay.md
@@ -1,0 +1,5 @@
+---
+"@balloman/expo-google-maps": minor
+---
+
+Added the ability to show the user's location on the map

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -4,7 +4,8 @@ import {
   MarkerView,
   setApiKey,
 } from "@balloman/expo-google-maps";
-import React from "react";
+import * as Location from "expo-location";
+import React, { useEffect } from "react";
 import { Button, StyleSheet, View } from "react-native";
 
 import styleJson from "./style.json";
@@ -13,6 +14,32 @@ setApiKey(process.env.EXPO_PUBLIC_API_KEY!);
 
 export default function App() {
   const mapViewRef = React.useRef<MapFunctions>(null);
+  const [status, setStatus] = React.useState<Location.PermissionStatus>();
+
+  useEffect(() => {
+    Location.getForegroundPermissionsAsync()
+      .then(({ status }) => {
+        setStatus(status);
+      })
+      .catch(e => {
+        if (e instanceof TypeError) {
+          return;
+        }
+        console.error(e);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (status === Location.PermissionStatus.UNDETERMINED) {
+      Location.requestForegroundPermissionsAsync()
+        .then(({ status }) => {
+          setStatus(status);
+        })
+        .catch(e => {
+          console.log("error", e);
+        });
+    }
+  }, [status]);
 
   return (
     <View style={styles.container}>
@@ -23,6 +50,7 @@ export default function App() {
           zoom: 13,
         }}
         styleJson={JSON.stringify(styleJson)}
+        showUserLocation
         mapRef={mapViewRef}
         onMapIdle={({ cameraPosition }) =>
           console.log("cameraPosition", cameraPosition)

--- a/example/app.config.ts
+++ b/example/app.config.ts
@@ -34,5 +34,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         },
       },
     ],
+    "expo-location",
   ],
 });

--- a/example/ios/expogooglemapsexample.xcodeproj/project.pbxproj
+++ b/example/ios/expogooglemapsexample.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = expo.modules.googlemaps.example;
-				PRODUCT_NAME = expogooglemapsexample;
+				PRODUCT_NAME = "expogooglemapsexample";
 				SWIFT_OBJC_BRIDGING_HEADER = "expogooglemapsexample/expogooglemapsexample-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -391,7 +391,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = expo.modules.googlemaps.example;
-				PRODUCT_NAME = expogooglemapsexample;
+				PRODUCT_NAME = "expogooglemapsexample";
 				SWIFT_OBJC_BRIDGING_HEADER = "expogooglemapsexample/expogooglemapsexample-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/example/ios/expogooglemapsexample/Info.plist
+++ b/example/ios/expogooglemapsexample/Info.plist
@@ -48,6 +48,12 @@
         </dict>
       </dict>
     </dict>
+    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    <string>Allow $(PRODUCT_NAME) to access your location</string>
+    <key>NSLocationAlwaysUsageDescription</key>
+    <string>Allow $(PRODUCT_NAME) to access your location</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Allow $(PRODUCT_NAME) to access your location</string>
     <key>UILaunchStoryboardName</key>
     <string>SplashScreen</string>
     <key>UIRequiredDeviceCapabilities</key>

--- a/example/package.json
+++ b/example/package.json
@@ -10,10 +10,11 @@
   "dependencies": {
     "expo": "~49.0.15",
     "expo-build-properties": "~0.8.3",
-    "react": "18.2.0",
-    "react-native": "0.72.6",
+    "expo-location": "~16.1.0",
     "expo-splash-screen": "~0.20.5",
-    "expo-status-bar": "~1.6.0"
+    "expo-status-bar": "~1.6.0",
+    "react": "18.2.0",
+    "react-native": "0.72.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3150,6 +3150,11 @@ expo-keep-awake@~12.3.0:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-12.3.0.tgz#c42449ae19c993274ddc43aafa618792b6aec408"
   integrity sha512-ujiJg1p9EdCOYS05jh5PtUrfiZnK0yyLy+UewzqrjUqIT8eAGMQbkfOn3C3fHE7AKd5AefSMzJnS3lYZcZYHDw==
 
+expo-location@~16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/expo-location/-/expo-location-16.1.0.tgz#251a465790d6622f828fd18f0edb2a73b9664b72"
+  integrity sha512-/jfRyYrXb9vjr8HoYmVHnzEqnw+0jaoRbHsxj6ePPAbevXmvXZqYHFRtfZtQ+q32SB4X6kUAXu28eBcLS+tqaA==
+
 expo-modules-autolinking@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-1.5.1.tgz#363f90c172769ce12bf56c7be9ca0897adfc7a81"

--- a/ios/ExpoGoogleMapsModule.swift
+++ b/ios/ExpoGoogleMapsModule.swift
@@ -57,8 +57,11 @@ public class ExpoGoogleMapsModule: Module {
       }
       
       Prop("showUserLocation") { (view, showUserLocation: Bool ) in
+        print("showUserLocation", showUserLocation)
         if (showUserLocation) {
           view.mapView?.isMyLocationEnabled = true
+        } else {
+          view.mapView?.isMyLocationEnabled = false
         }
       }
       

--- a/ios/ExpoGoogleMapsModule.swift
+++ b/ios/ExpoGoogleMapsModule.swift
@@ -56,6 +56,12 @@ public class ExpoGoogleMapsModule: Module {
         }
       }
       
+      Prop("showUserLocation") { (view, showUserLocation: Bool ) in
+        if (showUserLocation) {
+          view.mapView?.isMyLocationEnabled = true
+        }
+      }
+      
       Events("onMapIdle")
       Events("onDidChange")
 

--- a/src/MapView.tsx
+++ b/src/MapView.tsx
@@ -57,6 +57,12 @@ type MapProperties = {
   mapRef?: React.Ref<MapFunctions>;
   /** A json string of the style to apply to the map, if needed. See here: https://mapstyle.withgoogle.com/ */
   styleJson?: string;
+  /** Controls whether the My Location dot and accuracy circle is enabled.
+   * Due to a limitation in expo modules, setting this prop to undefined does not update the map.
+   * It must be set to either true or false to change the state
+   * @default false
+   */
+  showUserLocation?: boolean;
 } & ViewProps;
 
 type NativeViewProps = MapProperties & {


### PR DESCRIPTION
This pull request adds the ability to show the user's location on the map. The `showUserLocation` prop controls whether the My Location dot and accuracy circle is enabled.

Closes #7.
Dependent on #12.