### PR TITLE
fix(map): fix markers not displaying correctly

### DIFF
--- a/.changeset/many-shirts-beam.md
+++ b/.changeset/many-shirts-beam.md
@@ -1,0 +1,5 @@
+---
+"@balloman/expo-google-maps": patch
+---
+
+Fixed markers not displaying correctly if the size wasn't set

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -6,7 +6,7 @@ import {
 } from "@balloman/expo-google-maps";
 import * as Location from "expo-location";
 import React, { useEffect } from "react";
-import { Button, StyleSheet, View } from "react-native";
+import { Button, StyleSheet, Text, View } from "react-native";
 
 import styleJson from "./style.json";
 
@@ -96,11 +96,11 @@ export default function App() {
           <View
             style={{
               alignItems: "center",
-              backgroundColor: "red",
-              width: 100,
-              height: 100,
+              backgroundColor: "blue",
             }}
-          />
+          >
+            <Text>Hello World</Text>
+          </View>
         </MarkerView>
       </MapView>
       <View style={{ position: "absolute", top: "50%", alignSelf: "center" }}>

--- a/ios/Views/MapView.swift
+++ b/ios/Views/MapView.swift
@@ -40,6 +40,7 @@ class MapView: ExpoView, GMSMapViewDelegate {
       markerView.setMap(withMap: mapView)
       markers[key] = markerView
     }
+    super.insertReactSubview(subview, at: atIndex)
   }
   
   override func removeReactSubview(_ subview: UIView!) {
@@ -49,6 +50,7 @@ class MapView: ExpoView, GMSMapViewDelegate {
       markerView.gmsMarker.map = nil
       markers.removeValue(forKey: key)
     }
+    super.removeReactSubview(subview)
   }
   
   func animateCamera(to: GMSCameraPosition, animationOptions: AnimateOptions) {

--- a/src/MarkerView.tsx
+++ b/src/MarkerView.tsx
@@ -1,5 +1,6 @@
 import { requireNativeViewManager } from "expo-modules-core";
 import * as React from "react";
+import { View } from "react-native";
 
 import { Coordinate } from "./ExpoGoogleMaps.types";
 
@@ -27,5 +28,11 @@ const NativeView: React.ComponentType<MarkerViewProps> =
   requireNativeViewManager("ExpoGoogleMapsMarker");
 
 export function MarkerView(props: MarkerViewProps) {
-  return <NativeView {...props} />;
+  return (
+    <NativeView {...props}>
+      {props.children && ( // Due to some weirdness with the native view, we need to wrap the children in an absolute view
+        <View style={{ position: "absolute" }}>{props.children}</View>
+      )}
+    </NativeView>
+  );
 }


### PR DESCRIPTION
This pull request fixes an issue where markers were not displaying correctly if the size wasn't set. The changes include updating the marker view to wrap its children in an absolute view, and updating to call the super when adding a subview on the map