### PR TITLE
Rename the apiKey property

### DIFF
--- a/.changeset/polite-cats-build.md
+++ b/.changeset/polite-cats-build.md
@@ -1,0 +1,5 @@
+---
+"@balloman/expo-google-maps": minor
+---
+
+Renamed the apiKey property to be androiApiKey to better reflect usage

--- a/.changeset/polite-cats-build.md
+++ b/.changeset/polite-cats-build.md
@@ -2,4 +2,4 @@
 "@balloman/expo-google-maps": minor
 ---
 
-Renamed the apiKey property to be androiApiKey to better reflect usage
+Renamed the `apiKey` property to `androidApiKey` to clarify its specific use for Android configurations in the Google Maps SDK.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A module to allow the use of the Google Maps SDK as well. Expo Native module for improved performance over react-native-maps
 
+# Setup
+On android, use the plugin
+On iOS, call the setApiKey function
+
 # Feature Roadmap
 
 - [x] Map Placement

--- a/example/app.config.ts
+++ b/example/app.config.ts
@@ -38,7 +38,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       "../app.plugin.js",
       {
-        apiKey: process.env.API_KEY,
+        androidApiKey: process.env.API_KEY,
       },
     ],
   ],

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -4,9 +4,9 @@ import {
   withAndroidManifest,
 } from "@expo/config-plugins";
 
-const withAndroidApiKey: ConfigPlugin<{ apiKey: string }> = (
+const withAndroidApiKey: ConfigPlugin<{ androidApiKey: string }> = (
   config,
-  { apiKey },
+  { androidApiKey },
 ) => {
   config = withAndroidManifest(config, config => {
     const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(
@@ -16,7 +16,7 @@ const withAndroidApiKey: ConfigPlugin<{ apiKey: string }> = (
     AndroidConfig.Manifest.addMetaDataItemToMainApplication(
       mainApplication,
       "com.google.android.geo.API_KEY",
-      apiKey,
+      androidApiKey,
     );
 
     return config;


### PR DESCRIPTION
This PR renames the apiKey property in the config plugin to be androidApiKey to better reflect its usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Added setup instructions for using the Google Maps SDK on both Android and iOS platforms.
- **New Features**
	- Modified the configuration key for better clarity and specificity in the app's environment settings.
- **Refactor**
	- Updated parameter naming for Google Maps API key configuration to enhance clarity and consistency across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->